### PR TITLE
Prepend strings to total word count / estimated reading time + change "less than a minute string"

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ readingTimeTarget: "id / class / element"
 <br />A two letter string that indicates the language to be used (default: "en").
 </li>
 
+<li>lessThanAMinuteString: string
+<br />Changes the "Less than a minute" in to given string (default: '').
+</li>
+
+<li>prependTimeString: string
+<br />Prepends a string before the estimated reading time (default: '').
+</li>
+
+<li>prependWordString: string
+<br />Prepends a string before the total word count (default: '').
+</li>
+
 </ol>
 
 #####Example:

--- a/build/readingTime.min.js
+++ b/build/readingTime.min.js
@@ -4,8 +4,10 @@ Name: Reading Time
 Dependencies: jQuery
 Author: Michael Lynch
 Author URL: http://michaelynch.com
-Date Created: August 14, 2013
+Date Created: January 24, 2014
 Licensed under the MIT license
 
 */
-;(function(a){a.fn.readingTime=function(o){if(!this.length){return this;}var g={readingTimeTarget:".eta",wordCountTarget:null,wordsPerMinute:270,round:true,lang:"en",remotePath:null,remoteTarget:null};var h=this;var c=a(this);h.settings=a.extend({},g,o);var e=h.settings.readingTimeTarget;var d=h.settings.wordCountTarget;var j=h.settings.wordsPerMinute;var m=h.settings.round;var b=h.settings.lang;var f=h.settings.remotePath;var l=h.settings.remoteTarget;if(b=="fr"){var k="Moins d'une minute";var n="min";}else{if(b=="de"){var k="Weniger als eine Minute";var n="min";}else{if(b=="es"){var k="Menos de un minuto";var n="min";}else{var k="Less than a minute";var n="min";}}}var i=function(v){var s=v.split(" ").length;var r=j/60;var p=s/r;var u=Math.round(p/60);var t=Math.round(p-u*60);if(m===true){if(u>0){c.find(e).text(u+" "+n);}else{c.find(e).text(k);}}else{var q=u+":"+t;c.find(e).text(q);}if(d!==""&&d!==undefined){c.find(d).text(s);}};c.each(function(){if(f!=null&&l!=null){a.get(f,function(p){i(a(p).children().text());});}else{i(c.text());}});};})(jQuery);
+(function(b){b.fn.readingTime=function(a){if(!this.length)return this;var c=b(this);this.settings=b.extend({},{readingTimeTarget:".eta",wordCountTarget:null,wordsPerMinute:270,round:!0,lang:"en",lessThanAMinuteString:"",prependTimeString:"",prependWordString:"",remotePath:null,remoteTarget:null},a);var f=this.settings.readingTimeTarget,g=this.settings.wordCountTarget,p=this.settings.wordsPerMinute,q=this.settings.round;a=this.settings.lang;var e=this.settings.lessThanAMinuteString,h=this.settings.prependTimeString,
+r=this.settings.prependWordString,k=this.settings.remotePath,s=this.settings.remoteTarget;if("fr"==a)var l=e||"Moins d'une minute",m="min";else l="de"==a?e||"Weniger als eine Minute":"es"==a?e||"Menos de un minuto":"nl"==a?e||"Minder dan een minuut":e||"Less than a minute",m="min";var n=function(a){a=a.split(" ").length;var b=a/(p/60),d=Math.round(b/60),b=Math.round(b-60*d);!0===q?0<d?c.find(f).text(h+d+" "+m):c.find(f).text(h+l):(d=d+":"+b,c.find(f).text(h+d));""!==g&&void 0!==g&&c.find(g).text(r+
+a)};c.each(function(){null!=k&&null!=s?b.get(k,function(a){n(b(a).children().text())}):n(c.text())})}})(jQuery);

--- a/src/readingTime.js
+++ b/src/readingTime.js
@@ -4,7 +4,7 @@ Name: Reading Time
 Dependencies: jQuery
 Author: Michael Lynch
 Author URL: http://michaelynch.com
-Date Created: August 14, 2013
+Date Created: January 24, 2014
 Licensed under the MIT license
 
 */
@@ -26,6 +26,9 @@ Licensed under the MIT license
 	        wordsPerMinute: 270,
 	        round: true,
 	        lang: 'en',
+			lessThanAMinuteString: '',
+			prependTimeString: '',
+			prependWordString: '',
 	        remotePath: null,
 	        remoteTarget: null
         }
@@ -45,41 +48,43 @@ Licensed under the MIT license
         var wordsPerMinute = plugin.settings.wordsPerMinute;
         var round = plugin.settings.round;
         var lang = plugin.settings.lang;
+		var lessThanAMinuteString = plugin.settings.lessThanAMinuteString;
+		var prependTimeString = plugin.settings.prependTimeString;
+		var prependWordString = plugin.settings.prependWordString;
         var remotePath = plugin.settings.remotePath;
         var remoteTarget = plugin.settings.remoteTarget;
         
         //if lang is set to french
         if(lang == 'fr') {
-        
-        	var lessThanAMinute = "Moins d'une minute";
+			
+        	var lessThanAMinute = lessThanAMinuteString || "Moins d'une minute";
         	
         	var minShortForm = 'min';
 	     
 	      //if lang is set to german  
         } else if(lang == 'de') {
-	        
-	        var lessThanAMinute = "Weniger als eine Minute";
+	        var lessThanAMinute = lessThanAMinuteString || "Weniger als eine Minute";
 	        
 	        var minShortForm = 'min';
 
         //if lang is set to spanish
         } else if(lang == 'es') {
 	        
-	        var lessThanAMinute = "Menos de un minuto";
+	        var lessThanAMinute = lessThanAMinuteString || "Menos de un minuto";
 	        
 	        var minShortForm = 'min';
 	        
         //if lang is set to dutch
         } else if(lang == 'nl') {
 	        
-	        var lessThanAMinute = "Minder dan een minuut";
+	        var lessThanAMinute = lessThanAMinuteString || "Minder dan een minuut";
 	        
 	        var minShortForm = 'min';
 	
 	//default lang is english
         } else {
 	        
-	        var lessThanAMinute = 'Less than a minute';
+	        var lessThanAMinute = lessThanAMinuteString || 'Less than a minute';
 	        
 	        var minShortForm = 'min';
 	        
@@ -109,12 +114,12 @@ Licensed under the MIT license
 				if(readingTimeMinutes > 0) {
 			
 					//set reading time by the minute
-					el.find(readingTimeTarget).text(readingTimeMinutes + ' ' + minShortForm);
+					el.find(readingTimeTarget).text(prependTimeString + readingTimeMinutes + ' ' + minShortForm);
 				
 				} else {
 					
 					//set reading time as less than a minute
-					el.find(readingTimeTarget).text(lessThanAMinute);
+					el.find(readingTimeTarget).text(prependTimeString + lessThanAMinute);
 					
 				}
 			
@@ -125,7 +130,7 @@ Licensed under the MIT license
 				var readingTime = readingTimeMinutes + ':' + readingTimeSeconds;
 				
 				//set reading time in minutes and seconds
-				el.find(readingTimeTarget).text(readingTime);
+				el.find(readingTimeTarget).text(prependTimeString + readingTime);
 				
 			}
 	
@@ -133,7 +138,7 @@ Licensed under the MIT license
 			if(wordCountTarget !== '' && wordCountTarget !== undefined) {
 			
 				//set word count
-				el.find(wordCountTarget).text(totalWords);
+				el.find(wordCountTarget).text(prependWordString + totalWords);
 			
 			}
 		


### PR DESCRIPTION
Hi, I really like your plugin! Thanks for this!

In my use case, I noticed that it would be nice to have the possibility to prepend text before the total word count and the estimated reading time. I also wanted to change the "Less than a minute" string, so I added this and the prepend functionality.
