### PR TITLE
fixed bug with negative seconds when round option is set to false

### DIFF
--- a/src/readingTime.js
+++ b/src/readingTime.js
@@ -104,8 +104,18 @@ Licensed under the MIT license
 			var totalReadingTimeSeconds = totalWords / wordsPerSecond;
 			
 			//define reading time in minutes
-			var readingTimeMinutes = Math.round(totalReadingTimeSeconds / 60);
-			
+			//if round is set to true
+			if(round === true) {
+
+				var readingTimeMinutes = Math.round(totalReadingTimeSeconds / 60);
+
+			//if round is set to false
+			} else {
+
+				var readingTimeMinutes = Math.floor(totalReadingTimeSeconds / 60);
+
+			}
+
 			//define remaining reading time seconds
 			var readingTimeSeconds = Math.round(totalReadingTimeSeconds - readingTimeMinutes * 60);
 			


### PR DESCRIPTION
Bug description : **2:50** expected instead of **3:-10**
If round option is set to false, readingTimeMinutes need to be
calculated with `Math.floor()` to avoid negative seconds.

![capture decran 2014-04-04 a 10 04 43](https://cloud.githubusercontent.com/assets/806883/2613068/d7847176-bbcf-11e3-8e34-5f2cc03dbbd6.png)
