### PR TITLE
Improved total words calculation

### DIFF
--- a/src/readingTime.js
+++ b/src/readingTime.js
@@ -103,7 +103,7 @@ Licensed under the MIT license
         var setTime = function(text) {
 
 	        //split text by spaces to define total words
-			var totalWords = text.split(' ').length;
+			var totalWords = text.trim().split(/\s+/g).length;
 			
 			//define words per second based on words per minute (wordsPerMinute)
 			var wordsPerSecond = wordsPerMinute / 60;


### PR DESCRIPTION
If the target is a complex DOM node, the amount of chained whitespace can be quite significant. I've seen it double the estimated word count because of the way the total is calculated here, this change yields far more accurate counts.
